### PR TITLE
Fix address returns for non-mainnet addresses

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -135,8 +135,7 @@ TxController.prototype.transformInput = function(options, input, index) {
   var address = input.getAddress();
   if (address) {
     address.network = this._network;
-    transformed.addr = this.common.translateOutputAddress(address.toString());
-      
+    transformed.addr = address.toString(this._network);
   } else {
     transformed.addr = null;
   }
@@ -172,8 +171,7 @@ TxController.prototype.transformOutput = function(options, output, index) {
   var address = output.getAddress();
   if (address) {
     address.network = this._network;
-    transformed.scriptPubKey.addresses = [this.common.translateOutputAddress(address.toString())];
-    
+    transformed.scriptPubKey.addresses = [address.toString(this._network)];
     transformed.scriptPubKey.type = address.getType();
   }
   return transformed;
@@ -195,7 +193,7 @@ TxController.prototype.transformInvTransaction = function(transaction) {
       }
 
       address.network = this._network;
-      address = self.common.translateOutputAddress(address.toString());
+      address = address.toString(this._network);
 
       var obj = {};
       obj[address] = output.value;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flosight-api",
   "description": "A Florincoin blockchain REST and web socket API service for Flocore Node.",
-  "version": "5.0.0-beta.73",
+  "version": "5.0.0-beta.74",
   "repository": "git://github.com/bitpay/flosight-api.git",
   "bugs": {
     "url": "https://github.com/bitpay/flosight-api/issues"


### PR DESCRIPTION
Currently, addresses that should be testnet addresses are being returned as mainnet addresses. This patch fixes that issue.